### PR TITLE
Fix sh script when under absolute spaced directory

### DIFF
--- a/src/main/bin/smartsprites.sh
+++ b/src/main/bin/smartsprites.sh
@@ -5,4 +5,4 @@
 #
 OPTS="-Xms64m -Xmx256m"
 
-java $OPTS -Djava.ext.dirs=`dirname $0`/lib org.carrot2.labs.smartsprites.SmartSprites "$@"
+java $OPTS "-Djava.ext.dirs=` dirname "$0" | sed 's/ /\\ /g' `/lib" org.carrot2.labs.smartsprites.SmartSprites $@


### PR DESCRIPTION
Use case:

```
> pwd
/tmp/some path with spaces

> ./smartsprites-0.2.10/smartsprites.sh
sage: smartsprites [CSS-FILES ...] [...]

> # Ok, works!
> # Let's try with absolute path

> /tmp/some\ path\ with\ spaces/smartsprites-0.2.10/smartsprites.sh
usage: dirname path
Exception in thread "main" java.lang.NoClassDefFoundError: org/carrot2/labs/smartsprites/SmartSprites
Caused by: java.lang.ClassNotFoundException: org.carrot2.labs.smartsprites.SmartSprites
    at java.net.URLClassLoader$1.run(URLClassLoader.java:202)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:190)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:306)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:301)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:247)

```
